### PR TITLE
Make `classproperty` decorator typed (mypy typing return annotations)

### DIFF
--- a/classproperties/__init__.py
+++ b/classproperties/__init__.py
@@ -1,7 +1,7 @@
-from typing import TypeVar, Generic
+from typing import Any, Callable, Generic, TypeVar
 from functools import cached_property
 
-T: TypeVar = TypeVar('T')
+T = TypeVar('T')
 
 
 class classproperty(property, Generic[T]):
@@ -11,10 +11,10 @@ class classproperty(property, Generic[T]):
     Credit to Denis Rhyzhkov on Stackoverflow: https://stackoverflow.com/a/13624858/1280629
     """
     
-    def __init__(self, func: Callable[[type[Any]], T]) -> None:
+    def __init__(self, func: Callable[[type], T]) -> None:
         super().__init__(func)
 
-    def __get__(self, owner_self: Any | None, owner_cls: type[Any]) -> T:
+    def __get__(self, owner_self: Any, owner_cls: type | None = None) -> T:
         return self.fget(owner_cls)
 
 

--- a/classproperties/__init__.py
+++ b/classproperties/__init__.py
@@ -14,7 +14,7 @@ class classproperty(property, Generic[T]):
     def __init__(self, func: Callable[[type[Any]], T]) -> None:
         super().__init__(func)
 
-    def __get__(self, instance: Any | None, owner: type[Any]) -> T:
+    def __get__(self, owner_self: Any | None, owner_cls: type[Any]) -> T:
         return self.fget(owner_cls)
 
 

--- a/classproperties/__init__.py
+++ b/classproperties/__init__.py
@@ -1,14 +1,20 @@
+from typing import TypeVar, Generic
 from functools import cached_property
 
+T: TypeVar = TypeVar('T')
 
-class classproperty(property):
+
+class classproperty(property, Generic[T]):
     """
     Decorator for a Class-level property.
 
     Credit to Denis Rhyzhkov on Stackoverflow: https://stackoverflow.com/a/13624858/1280629
     """
+    
+    def __init__(self, func: Callable[[type[Any]], T]) -> None:
+        super().__init__(func)
 
-    def __get__(self, owner_self, owner_cls):
+    def __get__(self, instance: Any | None, owner: type[Any]) -> T:
         return self.fget(owner_cls)
 
 

--- a/classproperties/__init__.py
+++ b/classproperties/__init__.py
@@ -11,7 +11,7 @@ class classproperty(property, Generic[T]):
     Credit to Denis Rhyzhkov on Stackoverflow: https://stackoverflow.com/a/13624858/1280629
     """
     
-    def __init__(self, func: Callable[[type], T]) -> None:
+    def __init__(self, func: Callable[[type | None], T]) -> None:
         super().__init__(func)
 
     def __get__(self, owner_self: Any, owner_cls: type | None = None) -> T:


### PR DESCRIPTION
When using [mypy](https://mypy-lang.org/) over code that includes the `classproperty` decorator, an error will be shown that `Untyped decorator makes function "..." untyped  [misc]`. To fix this, every instance of the decorator should be associated with a specific type that it will return (i.e. the type of object that the function, that it wraps, will return). This makes use of the [class-generics system of type annotations](https://mypy.readthedocs.io/en/stable/generics.html).