### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ with open(path.join(here, 'README.md')) as f:
 setup(
     name='classproperties',
 
-    version='0.1',
+    version='0.2',
     
-    python_requires='>3.0',
+    python_requires='>3.5',
 
     description='Decorators for classproperty and cached_classproperty',
     long_description=long_description,
@@ -24,6 +24,7 @@ setup(
     license='MIT, Copyright 2021',
 
     classifiers=[
+        'Typing :: Typed'
     ],
 
     keywords='',


### PR DESCRIPTION
Now that we use type-hints inline in `__init__.py`, the minimum required Python version is 3.5 as this is when type-hints were introduced ([PEP 484](https://peps.python.org/pep-0484/)).

Due to this increased minimum required Python version I would also recommend we increment the version.