### PR TITLE
Fix incorrect minimum required Python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
 
     version='0.2',
     
-    python_requires='>3.5',
+    python_requires='>=3.5',
 
     description='Decorators for classproperty and cached_classproperty',
     long_description=long_description,


### PR DESCRIPTION
Python 3.5 is allowed, so `>=3.5` should be used instead of `>3.5`.